### PR TITLE
Use static, dependabot-parseable forms in gemspec

### DIFF
--- a/rspec-twirp.gemspec
+++ b/rspec-twirp.gemspec
@@ -1,5 +1,4 @@
 require_relative "lib/rspec/twirp/version"
-package = RSpec::Twirp
 
 Gem::Specification.new do |s|
   s.authors     = ["Daniel Pepper"]
@@ -7,9 +6,9 @@ Gem::Specification.new do |s|
   s.files       = `git ls-files * ':!:spec'`.split("\n")
   s.homepage    = "https://github.com/dpep/rspec-twirp"
   s.license     = "MIT"
-  s.name        = File.basename(__FILE__).split(".")[0]
-  s.summary     = package.to_s
-  s.version     = package.const_get "VERSION"
+  s.name        = "rspec-twirp"
+  s.summary     = "RSpec::Twirp"
+  s.version     = RSpec::Twirp::VERSION
 
   s.required_ruby_version = ">= 3.2"
 


### PR DESCRIPTION
## Summary

Dependabot's gemspec parser is **static** — it doesn't eval Ruby, it reads the AST and only handles literal `s.name = "string"` and `s.version = SomeConst::VERSION`. The dynamic forms we had defeated that.

When dependabot can't extract the version statically it falls back to `0.0.1` and writes that into `Gemfile.lock`, which then fails CI in frozen mode (gem version mismatch). See dpep/meddleware_rb#18 for the original diagnosis.

This PR switches to the canonical Bundler-scaffold shape:

```ruby
s.name    = "rspec-twirp"
s.version = RSpec::Twirp::VERSION
```


## Test plan

- [x] `Bundler.load_gemspec("rspec-twirp.gemspec")` parses statically to name=`rspec-twirp`, version=`0.4.1`
- [x] `bundle install` runs cleanly

## Pattern reference

- dpep/meddleware_rb#18 (diagnosis)
- dpep/amenable_rb#7 (template)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
